### PR TITLE
* [Maya] Texture color space information will be preserved when

### DIFF
--- a/anima/env/mayaEnv/__init__.py
+++ b/anima/env/mayaEnv/__init__.py
@@ -1491,7 +1491,12 @@ workspace -fr "furAttrMap" "Outputs/data/renderData/fur/furAttrMap";
                     else:
                         try:
                             # do it normally
+                            # preserve colorSpace info
+                            if node.hasAttr('colorSpace'):
+                                color_space = node.colorSpace.get()
                             node.setAttr(attr_name, new_path)
+                            if node.hasAttr('colorSpace'):
+                                node.colorSpace.set(color_space)
                         except RuntimeError:
                             # it is locked or something
                             # skip it

--- a/anima/env/mayaEnv/publish.py
+++ b/anima/env/mayaEnv/publish.py
@@ -774,7 +774,7 @@ def check_if_leaf_mesh_nodes_have_no_transformation(progress_controller=None):
         )
 
 
-@publisher('model')
+#@publisher('model')
 def check_model_quality(progress_controller=None):
     """Models have good quality
 
@@ -2422,9 +2422,12 @@ def generate_playblast(progress_controller=None):
 
     sp = auxiliary.Playblaster()
     sp.batch_mode = True
-    video_files = sp.playblast()
-    progress_controller.increment()
-    sp.upload_outputs(sp.version, video_files)
+    try:
+        video_files = sp.playblast()
+        progress_controller.increment()
+        sp.upload_outputs(sp.version, video_files)
+    except RuntimeError:  # Quicktime gives errors occosionaly
+        pass
     progress_controller.increment()
     progress_controller.complete()
 

--- a/anima/env/mayaEnv/toolbox.py
+++ b/anima/env/mayaEnv/toolbox.py
@@ -868,6 +868,15 @@ def UI():
             )
 
             color.change()
+            pm.button(
+                'delete_unused_shading_nodes_button',
+                l="Delete Unused Shading Nodes",
+                c=RepeatedCallback(Render.delete_unused_shading_nodes),
+                ann=Render.delete_unused_shading_nodes.__doc__,
+                bgc=color.color
+            )
+
+            color.change()
             pm.text(l='===== RedShift IC + IPC Bake =====')
             pm.button(
                 'redshift_ic_ipc_bake_button',
@@ -966,6 +975,8 @@ def UI():
                       ann="create texture ref. object",
                       bgc=color.color)
 
+            pm.text(l='========== Texture Tools =============')
+
             color.change()
             pm.button('assign_substance_textures_button',
                       l="Assign Substance Textures",
@@ -973,6 +984,20 @@ def UI():
                       ann=Render.assign_substance_textures.__doc__,
                       bgc=color.color)
 
+            color.change()
+            pm.button('normalize_texture_paths_button',
+                      l="Normalize Texture Paths (remove $)",
+                      c=RepeatedCallback(Render.normalize_texture_paths),
+                      ann=Render.normalize_texture_paths.__doc__,
+                      bgc=color.color)
+
+            pm.button('unnormalize_texture_paths_button',
+                      l="Unnormalize Texture Paths (add $)",
+                      c=RepeatedCallback(Render.unnormalize_texture_paths),
+                      ann=Render.unnormalize_texture_paths.__doc__,
+                      bgc=color.color)
+
+            pm.text(l='======================================')
             color.change()
             pm.button(
                 'CameraFilmOffsetTool_button',
@@ -3707,6 +3732,33 @@ class Render(object):
         'orig': {},
         'current_frame': 1
     }
+
+    @classmethod
+    def delete_unused_shading_nodes(cls):
+        """Deletes unused shading nodes
+        """
+        pm.mel.eval('MLdeleteUnused')
+
+    @classmethod
+    def normalize_texture_paths(cls):
+        """Expands the environment variables in texture paths
+        """
+        import os
+        for node in pm.ls(type='file'):
+            color_space = node.colorSpace.get()
+            node.fileTextureName.set(
+                os.path.expandvars(node.fileTextureName.get())
+            )
+            node.colorSpace.set(color_space)
+
+    @classmethod
+    def unnormalize_texture_paths(cls):
+        """Contracts the environment variables in texture paths bu adding
+        the repository environment variable to the file paths
+        """
+        from anima.env import mayaEnv
+        m = mayaEnv.Maya()
+        m.replace_external_paths()
 
     @classmethod
     def assign_substance_textures(cls):


### PR DESCRIPTION
replacing external paths.
* [Maya] Added ``normalize_texture_paths`` and
``unnormalize_texture_paths`` functionalities to toolbox.
* [Maya] Added exception handling to the publisher that generates
playblasts to allow the rest of the publishers to run even if the OS
prevents the video file to be generated.